### PR TITLE
added command to reverse selected lines; account for partially selected lines and multiple selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Unique Lines
 
-Keep unique lines of text and remove duplicates from current selection. Also includes a command to shuffle currently selected lines.
+Keep unique lines of text and remove duplicates from current selection. Also includes commands to reverse and shuffle currently selected lines.
 
 ## Commands
 
  - Unique Lines - Keep unique lines from selection
  - Unique Lines - Shuffle/Randomize the order of selected lines
+ - Unique Lines - Reverse selected lines
 
 ## Release Notes
 

--- a/extension.js
+++ b/extension.js
@@ -1,58 +1,110 @@
 var vscode = require('vscode');
 
 function activate(context) {
-    var disposableKeepUnique = vscode.commands.registerCommand('unique-lines.keepUnique', function () {
-        var editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return; // No open text editor
-        }
-
-        var selection = editor.selection;
-        var text = editor.document.getText(selection);
-        var lines = text.split('\n')
-
-        var unique_lines = [];
-        lines.forEach(function(line) {
-            if (unique_lines.indexOf(line) < 0) {
-                unique_lines.push(line);
-            }
-        }, this);
-
-        editor.edit(function (editBuilder) {
-            editBuilder.replace(selection, unique_lines.join('\n'));
+    var disposableKeepUnique = vscode.commands.registerTextEditorCommand('unique-lines.keepUnique', function(editor, edit) {
+        run(function() {
+            transformLines(editor, edit, function(lines) {
+                var unique_lines = [];
+                lines.forEach(function(line) {
+                    if (unique_lines.indexOf(line) < 0) {
+                        unique_lines.push(line);
+                    }
+                }, this);
+                return unique_lines;
+            });
         });
     });
 
-    var disposableShuffle = vscode.commands.registerCommand('unique-lines.shuffle', function () {
-        var editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return; // No open text editor
-        }
+    var disposableReverse = vscode.commands.registerTextEditorCommand('unique-lines.reverse', function(editor, edit) {
+        run(function() {
+            transformLines(editor, edit, function(lines) {
+                return lines.slice().reverse();
+            });
+        });
+    });
 
-        var selection = editor.selection;
-        var text = editor.document.getText(selection);
-        var lines = text.split('\n');
-
-        if (lines[lines.length - 1] == "\n") {
-            lines.splice(-1, 1);
-        }
-
-        var shuffled_lines = shuffleArray(lines)
-
-        editor.edit(function (editBuilder) {
-            editBuilder.replace(selection, shuffled_lines.join('\n'));
+    var disposableShuffle = vscode.commands.registerTextEditorCommand('unique-lines.shuffle', function(editor, edit) {
+        run(function() {
+            transformLines(editor, edit, shuffleArray);
         });
     });
 
     context.subscriptions.push(disposableKeepUnique);
+    context.subscriptions.push(disposableReverse);
     context.subscriptions.push(disposableShuffle);
 }
 exports.activate = activate;
+
 
 // this method is called when your extension is deactivated
 function deactivate() {
 }
 exports.deactivate = deactivate;
+
+
+function run(callback) {
+    try {
+        callback();
+    }
+    catch (e) {
+        console.error(e);
+        throw e;
+    }
+}
+
+
+function transformLines(editor, edit, callback) {
+    var document = editor.document;
+    var lineCount = document.lineCount;
+
+    var selections = editor.selections;
+    if (!selections.length) return;
+
+    var lines = {}; // <- map of line numbers
+    selections.forEach(function(selection) {
+
+        // ignore empty lines at the beginning of selection
+        for (var pos = selection.start;
+            pos.line + 1 < lineCount && pos.character == document.lineAt(pos).range.end.character;
+            pos = new vscode.Position(pos.line + 1, 0)) { }
+        var startLine = pos.line;
+
+        // ignore empty lines at the end of selection
+        for (var pos = selection.end;
+            pos.line > 0 && pos.character == 0;
+            pos = document.lineAt(pos.line - 1).range.end) { }
+        var endLine = pos.line;
+
+        for (var line = startLine; line <= endLine; ++line)
+            lines[line] = true;
+    });
+
+    // lines <- sorted array of line numbers
+    lines = Object.keys(lines);
+    if (lines.length < 2) return;
+    lines = lines.map(function(line) { return parseInt(line); });
+    lines.sort(function(a, b) { return a - b; });
+
+    // lines <- sorted array of vscode ranges
+    lines = lines.map(function(line) {
+        return document.lineAt(line).range;
+    });
+
+    texts = lines.map(function(line) {
+        return document.getText(line);
+    });
+    texts = callback(texts);
+
+    for (var i = 0; i < lines.length && i < texts.length; ++i)
+        edit.replace(lines[i], texts[i]);
+    for (var i = texts.length; i < lines.length; ++i)
+        edit.replace(lines[i], "");
+    if (texts.length > lines.length) {
+        var appendix = "\n" + texts.slice(lines.length).join("\n");
+        edit.insert(lines[lines.length - 1].end, appendix);
+    }
+}
+
 
 function shuffleArray(array) {
     for (var i = array.length - 1; i > 0; i--) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "unique-lines",
     "displayName": "Unique Lines",
-    "description": "Keep unique lines of text and remove duplicates from current selection. Also includes a command to shuffle currently selected lines.",
+    "description": "Keep unique lines of text and remove duplicates from current selection. Also includes commands to reverse and shuffle currently selected lines.",
     "version": "1.0.0",
     "publisher": "bibhasdn",
     "icon": "images/logo_128.png",
@@ -17,6 +17,7 @@
     ],
     "activationEvents": [
         "onCommand:unique-lines.keepUnique",
+        "onCommand:unique-lines.reverse",
         "onCommand:unique-lines.shuffle"
     ],
     "main": "./extension",
@@ -24,6 +25,9 @@
         "commands": [{
             "command": "unique-lines.keepUnique",
             "title": "Unique Lines - Keep unique lines from selection"
+        }, {
+            "command": "unique-lines.reverse",
+            "title": "Unique Lines - Reverse selected lines"
         }, {
             "command": "unique-lines.shuffle",
             "title": "Unique Lines - Shuffle/Randomize the order of selected lines"


### PR DESCRIPTION
Hello!

This is a major rewrite of the plugin. I believe I've made it more maintainable - see how simple the new reverse-lines function is!

On my way I have fixed a few bugs, including the one described in #1.

The new reverse-lines function sort-of completes the set, making VS Code equivalent to Sublime Text in terms of line operations (Sublime Text has Permute Lines > { Reverse, Unique, Shuffle }).

I hope that you will find time to review, test and accept my changes. Instead of releasing a new plugin I would like to see these changes in yours, because I think the many existing users of it will benefit from the new version.

Looking forward to your feedback.